### PR TITLE
Fix match_all query to be compliant with ER 5.4

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -262,7 +262,7 @@ class ElasticEngine extends Engine
         } else {
             $payload = $this->buildSearchQueryPayload(
                 $builder,
-                ['must' => ['match_all' => []]],
+                ['must' => ['match_all' => new \stdClass()]],
                 $options
             );
 


### PR DESCRIPTION
Line 265:
match_all query has to be an {} in order to work with ER > 5.0